### PR TITLE
added interface to macro _KNOMI_STATUS

### DIFF
--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -983,11 +983,9 @@ void loop()
           }else if(httpswitch==2){
             http.begin("http://"+klipper_ip+"/printer/objects/query?display_status"); //获取打印
           }else if(httpswitch==3){
-            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20G28"); //获取home状态
+            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20_KNOMI_STATUS"); //获取home状态
           }else if(httpswitch==4){
-            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20BED_MESH_CALIBRATE"); //获取levelling状态
-          }else if(httpswitch==5){
-            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20_KNOMI_STATUS"); // independant for home and leveling
+            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20_KNOMI_STATUS"); //获取levelling状态
           }else{
 
           }

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -1080,7 +1080,7 @@ void loop()
                   httpswitch = 3;
               }else if(httpswitch == 3){   //home状态
 
-                  String nameStr8 = doc["result"]["status"]["gcode_macro G28"]["homing"].as<String>();
+                  String nameStr8 = doc["result"]["status"]["gcode_macro _KNOMI_STATUS"]["homing"].as<String>();
                   Serial.println(nameStr8);
 
                   if(nameStr8 == "true"){
@@ -1094,7 +1094,7 @@ void loop()
                   httpswitch = 4;
               }else if(httpswitch == 4){   //levelling状态
 
-                  String nameStr9 = doc["result"]["status"]["gcode_macro BED_MESH_CALIBRATE"]["probing"].as<String>();
+                  String nameStr9 = doc["result"]["status"]["gcode_macro _KNOMI_STATUS"]["probing"].as<String>();
                   Serial.println(nameStr9);
 
                   if(nameStr9 == "true"){
@@ -1103,29 +1103,6 @@ void loop()
                       timer_contne = 0;                   
                   }else{
                       levelling_status = 0; 
-                  }
-
-                  httpswitch = 5;
-              }else if(httpswitch == 5){   // homing and leveling
-
-                  String nameStr10 = doc["result"]["status"]["gcode_macro _KNOMI_STATUS"]["probing"].as<String>();
-                  Serial.println(nameStr10);
-                  String nameStr11 = doc["result"]["status"]["gcode_macro _KNOMI_STATUS"]["homing"].as<String>();
-                  Serial.println(nameStr11);
-
-                  if(nameStr10 == "true"){
-                      levelling_status = 1;    
-                      display_step = 13;  //更快进入显示  
-                      timer_contne = 0;                   
-                  }else{
-                      levelling_status = 0; 
-                  }
-                  if(nameStr11 == "true"){
-                      homing_status = 1; 
-                      display_step = 12;  //更快进入显示 
-                      timer_contne = 0;  
-                  }else{
-                      homing_status = 0;  
                   }
 
                   httpswitch = 1;

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -1125,7 +1125,7 @@ void loop()
                       display_step = 12;  //更快进入显示 
                       timer_contne = 0;  
                   }else{
-                      levelling_status = 0; 
+                      homing_status = 0;  
                   }
 
                   httpswitch = 1;

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -986,6 +986,8 @@ void loop()
             http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20G28"); //获取home状态
           }else if(httpswitch==4){
             http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20BED_MESH_CALIBRATE"); //获取levelling状态
+          }else if(httpswitch==5){
+            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20KNOMI_STATUS"); // independant for home and leveling
           }else{
 
           }
@@ -1099,6 +1101,29 @@ void loop()
                       levelling_status = 1;    
                       display_step = 13;  //更快进入显示  
                       timer_contne = 0;                   
+                  }else{
+                      levelling_status = 0; 
+                  }
+
+                  httpswitch = 5;
+              }else if(httpswitch == 5){   // homing and leveling
+
+                  String nameStr10 = doc["result"]["status"]["gcode_macro KNOMI_STATUS"]["probing"].as<String>();
+                  Serial.println(nameStr10);
+                  String nameStr11 = doc["result"]["status"]["gcode_macro KNOMI_STATUS"]["homing"].as<String>();
+                  Serial.println(nameStr11);
+
+                  if(nameStr10 == "true"){
+                      levelling_status = 1;    
+                      display_step = 13;  //更快进入显示  
+                      timer_contne = 0;                   
+                  }else{
+                      levelling_status = 0; 
+                  }
+                  if(nameStr11 == "true"){
+                      homing_status = 1; 
+                      display_step = 12;  //更快进入显示 
+                      timer_contne = 0;  
                   }else{
                       levelling_status = 0; 
                   }

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -987,7 +987,7 @@ void loop()
           }else if(httpswitch==4){
             http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20BED_MESH_CALIBRATE"); //获取levelling状态
           }else if(httpswitch==5){
-            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20KNOMI_STATUS"); // independant for home and leveling
+            http.begin("http://"+klipper_ip+"/printer/objects/query?gcode_macro%20_KNOMI_STATUS"); // independant for home and leveling
           }else{
 
           }
@@ -1108,9 +1108,9 @@ void loop()
                   httpswitch = 5;
               }else if(httpswitch == 5){   // homing and leveling
 
-                  String nameStr10 = doc["result"]["status"]["gcode_macro KNOMI_STATUS"]["probing"].as<String>();
+                  String nameStr10 = doc["result"]["status"]["gcode_macro _KNOMI_STATUS"]["probing"].as<String>();
                   Serial.println(nameStr10);
-                  String nameStr11 = doc["result"]["status"]["gcode_macro KNOMI_STATUS"]["homing"].as<String>();
+                  String nameStr11 = doc["result"]["status"]["gcode_macro _KNOMI_STATUS"]["homing"].as<String>();
                   Serial.println(nameStr11);
 
                   if(nameStr10 == "true"){


### PR DESCRIPTION
Due to the errors with G28 and homing override, I created this PR. This PR consists of two parts:
- Changes in source code (main.cpp)
- Functional documentation (described in this PR text)

I added a new part of looking through the API calls for a macro called `_KNOMI_STATUS` instead of `G28` and `BED_MESH_CALIBRATE`.

It is NOT backwards compatible with the "original" version!
The new `_KNOMI_STATUS` macro would need to look like this

```
[gcode_macro _KNOMI_STATUS] 
variable_homing: False  
variable_probing: False  
gcode:  
``` 

with this it is now generally possible to set the status whereever it is needed.
Therefore just add the following lines where it is appropriate:

```
SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=homing VALUE=True
SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=homing VALUE=False
```
```
SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=probing VALUE=True
SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=probing VALUE=False
```

if you use a homing_override you can add it like this: (this is just a technical example!)
```
SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=homing VALUE=True
G28
SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=homing VALUE=False
```

This does not require a G28 override which is not possible when using homing_override.

My KNOMI display ships in a couple days, so i wasn't able to test this with a KNOMI display.