### PR TITLE
[gcode_macro BED_MESH_CALIBRATE]

### DIFF
--- a/KNOMI.cfg
+++ b/KNOMI.cfg
@@ -42,6 +42,24 @@ gcode:
   BTT_QUAD_GANTRY_LEVEL {rawparams}
   SET_GCODE_VARIABLE MACRO=_KNOMI_STATUS VARIABLE=qgling VALUE=False
 
+[gcode_macro BED_MESH_CALIBRATE]
+rename_existing: BED_MESH_CALIBRATE_BASE
+variable_probing:False
+
+gcode:
+  SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=probing VALUE=True
+  BED_MESH_CALIBRATE_BASE
+  SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=probing VALUE=False
+
+[gcode_macro G28]
+rename_existing: G0028
+variable_homing:False
+
+gcode:
+  SET_GCODE_VARIABLE MACRO=G28 VARIABLE=homing VALUE=True
+  G0028
+  SET_GCODE_VARIABLE MACRO=G28 VARIABLE=homing VALUE=False
+
 ## For printer without QGL but have Z_TILT
 #[gcode_macro QUAD_GANTRY_LEVEL]
 #gcode:


### PR DESCRIPTION
rename_existing: BED_MESH_CALIBRATE_BASE
variable_probing:False

gcode:
  SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=probing VALUE=True
  BED_MESH_CALIBRATE_BASE
  SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=probing VALUE=False

[gcode_macro G28]
rename_existing: G0028
variable_homing:False

gcode:
  SET_GCODE_VARIABLE MACRO=G28 VARIABLE=homing VALUE=True
  G0028
  SET_GCODE_VARIABLE MACRO=G28 VARIABLE=homing VALUE=False