### PR TITLE
Prevent Negative temps from being set by the knob in UI

### DIFF
--- a/src/ui_overlay/lv_set_temp.cpp
+++ b/src/ui_overlay/lv_set_temp.cpp
@@ -144,7 +144,7 @@ void lv_loop_set_temp_screen(void) {
         if (event == KNOB_INC) {
             frontend_target += TARGET_INC;
             lv_img_set_angle(ui_img_set_temp_dial, angle += DIAL_ANGLE_INC);
-        } else if (event == KNOB_DEC) {
+        } else if (event == KNOB_DEC && (frontend_target - TARGET_INC >= 0)) {
             frontend_target -= TARGET_INC;
             lv_img_set_angle(ui_img_set_temp_dial, angle -= DIAL_ANGLE_INC);
         }


### PR DESCRIPTION
Currently you can set negative temperatures on the UI this prevents that.